### PR TITLE
don't force 8 cpus for certain tasks

### DIFF
--- a/bauhaus/workflows/secondary/ccs.py
+++ b/bauhaus/workflows/secondary/ccs.py
@@ -23,7 +23,7 @@ def genCCS(pflow, subreadSets):
         with pflow.context("movieName", movieName(subreadSet)):
             outBam = pflow.formatInContext("{condition}/ccs/{movieName}.ccs.bam")
             ccsDiagnostics= pflow.formatInContext("{condition}/{movieName}.ccs-report.txt")
-            buildVariables = dict(outBam=outBam, ncpus=8, ccsDiagnostics=ccsDiagnostics)
+            buildVariables = dict(outBam=outBam, ccsDiagnostics=ccsDiagnostics)
             ccsSets.extend(pflow.genBuildStatement(
                 ["{condition}/ccs/{movieName}.consensusreadset.xml"],
                 "ccs",
@@ -45,7 +45,7 @@ def genChunkedCCS(pflow, subreadSets, splitFactor=8, doMerge=True):
                 with pflow.context("chunkNum", i):
                     outBam = pflow.formatInContext("{condition}/ccs_chunks/{movieName}.chunk{chunkNum}.ccs.bam")
                     ccsDiagnostics = pflow.formatInContext("{condition}/ccs_chunks/{movieName}.chunk{chunkNum}.ccs-report.txt")
-                    buildVariables = dict(outBam=outBam, ncpus=8, ccsDiagnostics=ccsDiagnostics)
+                    buildVariables = dict(outBam=outBam, ccsDiagnostics=ccsDiagnostics)
                     buildStmt = pflow.genBuildStatement(
                         ["{condition}/ccs_chunks/{movieName}.chunk{chunkNum}.consensusreadset.xml"],
                         "ccs",

--- a/bauhaus/workflows/secondary/mapping.py
+++ b/bauhaus/workflows/secondary/mapping.py
@@ -31,7 +31,7 @@ def genMapping(pflow, subreadSets, reference):
     alignmentSets = []
     for subreadSet in subreadSets:
         with pflow.context("entityName", entityName(subreadSet)):
-            buildVariables = dict(reference=reference, ncpus=8)
+            buildVariables = dict(reference=reference)
             alignmentSets.extend(pflow.genBuildStatement(
                 ["{condition}/mapping/{entityName}.alignmentset.xml"],
                 "map",
@@ -51,7 +51,7 @@ def genMappingCCS(pflow, ccsSets, reference):
     alignmentSets = []
     for ccsSet in ccsSets:
         with pflow.context("entityName", entityName(ccsSet)):
-            buildVariables = dict(reference=reference, ncpus=8)
+            buildVariables = dict(reference=reference)
             alignmentSets.extend(pflow.genBuildStatement(
                 ["{condition}/ccs_mapping/{entityName}.consensusalignments.xml"],
                 "mapCCS",
@@ -74,7 +74,7 @@ def genChunkedMapping(pflow, subreadSets, reference, splitFactor=8):
             subreadSetChunks = genSubreadSetSplit(pflow, subreadSet, splitFactor)
             for (i, subreadSetChunk) in enumerate(subreadSetChunks):
                 with pflow.context("chunkNum", i):
-                    buildVariables = dict(reference=reference, ncpus=8)
+                    buildVariables = dict(reference=reference)
                     buildStmt = pflow.genBuildStatement(
                         ["{condition}/mapping_chunks/{movieName}.chunk{chunkNum}.alignmentset.xml"],
                         "map",

--- a/bauhaus/workflows/secondary/unrolled.py
+++ b/bauhaus/workflows/secondary/unrolled.py
@@ -80,7 +80,7 @@ def genUnrolledMapping(pflow, unrolledReadSets, reference, splitFactor):
             unrolledReadSetChunks = genUnrolledReadSetSplit(pflow, unrolledReadSet, splitFactor)
             for (i, unrolledReadSetChunk) in enumerate(unrolledReadSetChunks):
                 with pflow.context("chunkNum", i):
-                    buildVariables = dict(reference=reference, ncpus=8)
+                    buildVariables = dict(reference=reference)
                     buildStmt = pflow.genBuildStatement(
                         ["{condition}/unrolled_mapping_chunks/{movieName}.chunk{chunkNum}.unrolledalignmentset.xml"],
                         "map_unrolled",

--- a/test/cram/ctFromRuns.t
+++ b/test/cram/ctFromRuns.t
@@ -90,49 +90,41 @@ as a small diff.
   
   build Ecoli/mapping_chunks/m54011_160305_235923.chunk0.alignmentset.xml: $
       map Ecoli/subreads_chunks/m54011_160305_235923.chunk0.subreadset.xml
-    ncpus = 8
     reference = $
         /mnt/secondary/iSmrtanalysis/current/common/references/ecoliK12_pbi_March2013/sequence/ecoliK12_pbi_March2013.fasta
   
   build Ecoli/mapping_chunks/m54011_160305_235923.chunk1.alignmentset.xml: $
       map Ecoli/subreads_chunks/m54011_160305_235923.chunk1.subreadset.xml
-    ncpus = 8
     reference = $
         /mnt/secondary/iSmrtanalysis/current/common/references/ecoliK12_pbi_March2013/sequence/ecoliK12_pbi_March2013.fasta
   
   build Ecoli/mapping_chunks/m54011_160305_235923.chunk2.alignmentset.xml: $
       map Ecoli/subreads_chunks/m54011_160305_235923.chunk2.subreadset.xml
-    ncpus = 8
     reference = $
         /mnt/secondary/iSmrtanalysis/current/common/references/ecoliK12_pbi_March2013/sequence/ecoliK12_pbi_March2013.fasta
   
   build Ecoli/mapping_chunks/m54011_160305_235923.chunk3.alignmentset.xml: $
       map Ecoli/subreads_chunks/m54011_160305_235923.chunk3.subreadset.xml
-    ncpus = 8
     reference = $
         /mnt/secondary/iSmrtanalysis/current/common/references/ecoliK12_pbi_March2013/sequence/ecoliK12_pbi_March2013.fasta
   
   build Ecoli/mapping_chunks/m54011_160305_235923.chunk4.alignmentset.xml: $
       map Ecoli/subreads_chunks/m54011_160305_235923.chunk4.subreadset.xml
-    ncpus = 8
     reference = $
         /mnt/secondary/iSmrtanalysis/current/common/references/ecoliK12_pbi_March2013/sequence/ecoliK12_pbi_March2013.fasta
   
   build Ecoli/mapping_chunks/m54011_160305_235923.chunk5.alignmentset.xml: $
       map Ecoli/subreads_chunks/m54011_160305_235923.chunk5.subreadset.xml
-    ncpus = 8
     reference = $
         /mnt/secondary/iSmrtanalysis/current/common/references/ecoliK12_pbi_March2013/sequence/ecoliK12_pbi_March2013.fasta
   
   build Ecoli/mapping_chunks/m54011_160305_235923.chunk6.alignmentset.xml: $
       map Ecoli/subreads_chunks/m54011_160305_235923.chunk6.subreadset.xml
-    ncpus = 8
     reference = $
         /mnt/secondary/iSmrtanalysis/current/common/references/ecoliK12_pbi_March2013/sequence/ecoliK12_pbi_March2013.fasta
   
   build Ecoli/mapping_chunks/m54011_160305_235923.chunk7.alignmentset.xml: $
       map Ecoli/subreads_chunks/m54011_160305_235923.chunk7.subreadset.xml
-    ncpus = 8
     reference = $
         /mnt/secondary/iSmrtanalysis/current/common/references/ecoliK12_pbi_March2013/sequence/ecoliK12_pbi_March2013.fasta
   
@@ -165,49 +157,41 @@ as a small diff.
   
   build Ecoli/mapping_chunks/m54011_160306_050740.chunk0.alignmentset.xml: $
       map Ecoli/subreads_chunks/m54011_160306_050740.chunk0.subreadset.xml
-    ncpus = 8
     reference = $
         /mnt/secondary/iSmrtanalysis/current/common/references/ecoliK12_pbi_March2013/sequence/ecoliK12_pbi_March2013.fasta
   
   build Ecoli/mapping_chunks/m54011_160306_050740.chunk1.alignmentset.xml: $
       map Ecoli/subreads_chunks/m54011_160306_050740.chunk1.subreadset.xml
-    ncpus = 8
     reference = $
         /mnt/secondary/iSmrtanalysis/current/common/references/ecoliK12_pbi_March2013/sequence/ecoliK12_pbi_March2013.fasta
   
   build Ecoli/mapping_chunks/m54011_160306_050740.chunk2.alignmentset.xml: $
       map Ecoli/subreads_chunks/m54011_160306_050740.chunk2.subreadset.xml
-    ncpus = 8
     reference = $
         /mnt/secondary/iSmrtanalysis/current/common/references/ecoliK12_pbi_March2013/sequence/ecoliK12_pbi_March2013.fasta
   
   build Ecoli/mapping_chunks/m54011_160306_050740.chunk3.alignmentset.xml: $
       map Ecoli/subreads_chunks/m54011_160306_050740.chunk3.subreadset.xml
-    ncpus = 8
     reference = $
         /mnt/secondary/iSmrtanalysis/current/common/references/ecoliK12_pbi_March2013/sequence/ecoliK12_pbi_March2013.fasta
   
   build Ecoli/mapping_chunks/m54011_160306_050740.chunk4.alignmentset.xml: $
       map Ecoli/subreads_chunks/m54011_160306_050740.chunk4.subreadset.xml
-    ncpus = 8
     reference = $
         /mnt/secondary/iSmrtanalysis/current/common/references/ecoliK12_pbi_March2013/sequence/ecoliK12_pbi_March2013.fasta
   
   build Ecoli/mapping_chunks/m54011_160306_050740.chunk5.alignmentset.xml: $
       map Ecoli/subreads_chunks/m54011_160306_050740.chunk5.subreadset.xml
-    ncpus = 8
     reference = $
         /mnt/secondary/iSmrtanalysis/current/common/references/ecoliK12_pbi_March2013/sequence/ecoliK12_pbi_March2013.fasta
   
   build Ecoli/mapping_chunks/m54011_160306_050740.chunk6.alignmentset.xml: $
       map Ecoli/subreads_chunks/m54011_160306_050740.chunk6.subreadset.xml
-    ncpus = 8
     reference = $
         /mnt/secondary/iSmrtanalysis/current/common/references/ecoliK12_pbi_March2013/sequence/ecoliK12_pbi_March2013.fasta
   
   build Ecoli/mapping_chunks/m54011_160306_050740.chunk7.alignmentset.xml: $
       map Ecoli/subreads_chunks/m54011_160306_050740.chunk7.subreadset.xml
-    ncpus = 8
     reference = $
         /mnt/secondary/iSmrtanalysis/current/common/references/ecoliK12_pbi_March2013/sequence/ecoliK12_pbi_March2013.fasta
   
@@ -252,49 +236,41 @@ as a small diff.
   
   build Lambda/mapping_chunks/m54008_160308_002050.chunk0.alignmentset.xml: $
       map Lambda/subreads_chunks/m54008_160308_002050.chunk0.subreadset.xml
-    ncpus = 8
     reference = $
         /mnt/secondary/iSmrtanalysis/current/common/references/lambdaNEB/sequence/lambdaNEB.fasta
   
   build Lambda/mapping_chunks/m54008_160308_002050.chunk1.alignmentset.xml: $
       map Lambda/subreads_chunks/m54008_160308_002050.chunk1.subreadset.xml
-    ncpus = 8
     reference = $
         /mnt/secondary/iSmrtanalysis/current/common/references/lambdaNEB/sequence/lambdaNEB.fasta
   
   build Lambda/mapping_chunks/m54008_160308_002050.chunk2.alignmentset.xml: $
       map Lambda/subreads_chunks/m54008_160308_002050.chunk2.subreadset.xml
-    ncpus = 8
     reference = $
         /mnt/secondary/iSmrtanalysis/current/common/references/lambdaNEB/sequence/lambdaNEB.fasta
   
   build Lambda/mapping_chunks/m54008_160308_002050.chunk3.alignmentset.xml: $
       map Lambda/subreads_chunks/m54008_160308_002050.chunk3.subreadset.xml
-    ncpus = 8
     reference = $
         /mnt/secondary/iSmrtanalysis/current/common/references/lambdaNEB/sequence/lambdaNEB.fasta
   
   build Lambda/mapping_chunks/m54008_160308_002050.chunk4.alignmentset.xml: $
       map Lambda/subreads_chunks/m54008_160308_002050.chunk4.subreadset.xml
-    ncpus = 8
     reference = $
         /mnt/secondary/iSmrtanalysis/current/common/references/lambdaNEB/sequence/lambdaNEB.fasta
   
   build Lambda/mapping_chunks/m54008_160308_002050.chunk5.alignmentset.xml: $
       map Lambda/subreads_chunks/m54008_160308_002050.chunk5.subreadset.xml
-    ncpus = 8
     reference = $
         /mnt/secondary/iSmrtanalysis/current/common/references/lambdaNEB/sequence/lambdaNEB.fasta
   
   build Lambda/mapping_chunks/m54008_160308_002050.chunk6.alignmentset.xml: $
       map Lambda/subreads_chunks/m54008_160308_002050.chunk6.subreadset.xml
-    ncpus = 8
     reference = $
         /mnt/secondary/iSmrtanalysis/current/common/references/lambdaNEB/sequence/lambdaNEB.fasta
   
   build Lambda/mapping_chunks/m54008_160308_002050.chunk7.alignmentset.xml: $
       map Lambda/subreads_chunks/m54008_160308_002050.chunk7.subreadset.xml
-    ncpus = 8
     reference = $
         /mnt/secondary/iSmrtanalysis/current/common/references/lambdaNEB/sequence/lambdaNEB.fasta
   
@@ -327,49 +303,41 @@ as a small diff.
   
   build Lambda/mapping_chunks/m54008_160308_053311.chunk0.alignmentset.xml: $
       map Lambda/subreads_chunks/m54008_160308_053311.chunk0.subreadset.xml
-    ncpus = 8
     reference = $
         /mnt/secondary/iSmrtanalysis/current/common/references/lambdaNEB/sequence/lambdaNEB.fasta
   
   build Lambda/mapping_chunks/m54008_160308_053311.chunk1.alignmentset.xml: $
       map Lambda/subreads_chunks/m54008_160308_053311.chunk1.subreadset.xml
-    ncpus = 8
     reference = $
         /mnt/secondary/iSmrtanalysis/current/common/references/lambdaNEB/sequence/lambdaNEB.fasta
   
   build Lambda/mapping_chunks/m54008_160308_053311.chunk2.alignmentset.xml: $
       map Lambda/subreads_chunks/m54008_160308_053311.chunk2.subreadset.xml
-    ncpus = 8
     reference = $
         /mnt/secondary/iSmrtanalysis/current/common/references/lambdaNEB/sequence/lambdaNEB.fasta
   
   build Lambda/mapping_chunks/m54008_160308_053311.chunk3.alignmentset.xml: $
       map Lambda/subreads_chunks/m54008_160308_053311.chunk3.subreadset.xml
-    ncpus = 8
     reference = $
         /mnt/secondary/iSmrtanalysis/current/common/references/lambdaNEB/sequence/lambdaNEB.fasta
   
   build Lambda/mapping_chunks/m54008_160308_053311.chunk4.alignmentset.xml: $
       map Lambda/subreads_chunks/m54008_160308_053311.chunk4.subreadset.xml
-    ncpus = 8
     reference = $
         /mnt/secondary/iSmrtanalysis/current/common/references/lambdaNEB/sequence/lambdaNEB.fasta
   
   build Lambda/mapping_chunks/m54008_160308_053311.chunk5.alignmentset.xml: $
       map Lambda/subreads_chunks/m54008_160308_053311.chunk5.subreadset.xml
-    ncpus = 8
     reference = $
         /mnt/secondary/iSmrtanalysis/current/common/references/lambdaNEB/sequence/lambdaNEB.fasta
   
   build Lambda/mapping_chunks/m54008_160308_053311.chunk6.alignmentset.xml: $
       map Lambda/subreads_chunks/m54008_160308_053311.chunk6.subreadset.xml
-    ncpus = 8
     reference = $
         /mnt/secondary/iSmrtanalysis/current/common/references/lambdaNEB/sequence/lambdaNEB.fasta
   
   build Lambda/mapping_chunks/m54008_160308_053311.chunk7.alignmentset.xml: $
       map Lambda/subreads_chunks/m54008_160308_053311.chunk7.subreadset.xml
-    ncpus = 8
     reference = $
         /mnt/secondary/iSmrtanalysis/current/common/references/lambdaNEB/sequence/lambdaNEB.fasta
   

--- a/test/cram/map.t
+++ b/test/cram/map.t
@@ -54,13 +54,11 @@ Let's try a very simple mapping job (no chunking)
   
   build Ecoli/mapping/m54011_160305_235923.alignmentset.xml: map $
       Ecoli/subreads/m54011_160305_235923.subreadset.xml
-    ncpus = 8
     reference = $
         /mnt/secondary/iSmrtanalysis/current/common/references/ecoliK12_pbi_March2013/sequence/ecoliK12_pbi_March2013.fasta
   
   build Ecoli/mapping/m54011_160306_050740.alignmentset.xml: map $
       Ecoli/subreads/m54011_160306_050740.subreadset.xml
-    ncpus = 8
     reference = $
         /mnt/secondary/iSmrtanalysis/current/common/references/ecoliK12_pbi_March2013/sequence/ecoliK12_pbi_March2013.fasta
   
@@ -78,13 +76,11 @@ Let's try a very simple mapping job (no chunking)
   
   build Lambda/mapping/m54008_160308_002050.alignmentset.xml: map $
       Lambda/subreads/m54008_160308_002050.subreadset.xml
-    ncpus = 8
     reference = $
         /mnt/secondary/iSmrtanalysis/current/common/references/lambdaNEB/sequence/lambdaNEB.fasta
   
   build Lambda/mapping/m54008_160308_053311.alignmentset.xml: map $
       Lambda/subreads/m54008_160308_053311.subreadset.xml
-    ncpus = 8
     reference = $
         /mnt/secondary/iSmrtanalysis/current/common/references/lambdaNEB/sequence/lambdaNEB.fasta
   


### PR DESCRIPTION
I don't know why this policy was enforced in the generator
